### PR TITLE
python: Add missing constructors of time_spec_t

### DIFF
--- a/host/lib/types/time_spec_python.hpp
+++ b/host/lib/types/time_spec_python.hpp
@@ -14,6 +14,9 @@ void export_time_spec()
     using time_spec_t = uhd::time_spec_t;
 
     bp::class_<time_spec_t>("time_spec", bp::init<double>())
+        //Additional constructors
+        .def(bp::init<time_t, double>())
+        .def(bp::init<time_t, long, double>())
 
         // Methods
         .def("from_ticks"     , &time_spec_t::from_ticks     )


### PR DESCRIPTION
Currently Python interface of time_spec_t exposes only constructor with 'double' parameter.
Other constructors are also important as they provide higher precision, so let's expose them
on Python API as well.
